### PR TITLE
Use an absolute path for eclipse

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ RUN rm scala-SDK-4.1.0-vfinal-2.11-linux.gtk.x86_64.tar.gz
 
 WORKDIR /eclipse
 
-CMD ./eclipse
+CMD /eclipse/eclipse


### PR DESCRIPTION
This makes it easy to change the working directory